### PR TITLE
Remove py2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ packages. Therefore, the buildout extends files from buildout.coredev on github.
 
 Prerequisites
 -------------
-- Python 2.6 or Python 2.7
+- Python 2.7
 - Python Virtualenv
 - Git
 


### PR DESCRIPTION
Python 2.6 is no longer officially supported on Plone 5.0.

Or that's what I think. At least we are not testing **at all** python 2.6 on Plone 5.0 on Jenkins, and  I think that's a conscious decision.
