### PR TITLE
Explicitly use python 2.7 for virtualenv.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,6 +3,6 @@
 # Usage:
 #     ./bootstrap.sh  # use buildout.cfg
 #     ./bootstrap.sh -c coredev.cfg  # use coredev.cfg
-virtualenv .
+virtualenv -p python2.7 .
 ./bin/pip install -r https://raw.githubusercontent.com/plone/buildout.coredev/5.1/requirements.txt
 ./bin/buildout "$@"


### PR DESCRIPTION
On systems with a Python 3  as default, the old style does not result in a working Plone.